### PR TITLE
feat: support Kotlin tree comments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,11 +160,12 @@ dependencies {
 
 def system = org.gradle.internal.os.OperatingSystem.current()
 def ideTypeStr = String.valueOf(ideType)
+def useDownloadedIde = Boolean.parseBoolean(String.valueOf(project.findProperty('useDownloadedIdea')))
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
     type = ideType
-    if (system.isMacOsX()) {
+    if (system.isMacOsX() && !useDownloadedIde) {
         localPath = "/Applications/IntelliJ IDEA.app"
     } else {
         version = ideaVersion

--- a/src/main/idea/io/github/linwancen/plugin/show/java/KotlinLangDoc.java
+++ b/src/main/idea/io/github/linwancen/plugin/show/java/KotlinLangDoc.java
@@ -1,6 +1,11 @@
 package io.github.linwancen.plugin.show.java;
 
+import com.intellij.ide.projectView.ProjectViewNode;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
 import com.intellij.psi.impl.file.PsiPackageBase;
 import com.intellij.psi.util.PsiTreeUtil;
 import io.github.linwancen.plugin.show.bean.LineInfo;
@@ -15,11 +20,20 @@ import org.jetbrains.kotlin.kdoc.psi.impl.KDocName;
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocSection;
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag;
 import org.jetbrains.kotlin.psi.KtAnnotated;
+import org.jetbrains.kotlin.psi.KtDeclaration;
+import org.jetbrains.kotlin.psi.KtFile;
+import org.jetbrains.kotlin.psi.KtNamedDeclaration;
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression;
 
 import java.util.List;
 
 public class KotlinLangDoc extends BaseTagLangDoc<KDocSection> {
+
+    public static final KotlinLangDoc INSTANCE = new KotlinLangDoc();
+
+    static {
+        LANG_DOC_MAP.put("kotlin", INSTANCE);
+    }
 
     @Override
     public @NotNull List<Class<? extends PsiElement>> getRefClass() {
@@ -29,6 +43,61 @@ public class KotlinLangDoc extends BaseTagLangDoc<KDocSection> {
     @Override
     public boolean show(@NotNull LineInfo info) {
         return info.appSettings.showLineEndCommentKotlin;
+    }
+
+    @Override
+    public @Nullable <T extends SettingsInfo> String treeDoc(@NotNull T info, ProjectViewNode<?> node,
+                                                             @NotNull Project project) {
+        @Nullable KtFile ktFile = ktFile(node, project);
+        if (ktFile == null) {
+            return null;
+        }
+        @NotNull String fileName = fileNameWithoutExtension(ktFile);
+        @Nullable String firstDoc = null;
+        for (@NotNull KtDeclaration declaration : ktFile.getDeclarations()) {
+            if (!(declaration instanceof KtNamedDeclaration)) {
+                continue;
+            }
+            @Nullable String name = ((KtNamedDeclaration) declaration).getName();
+            @Nullable String doc = resolveDocPrint(info, declaration);
+            if (doc == null) {
+                continue;
+            }
+            if (fileName.equals(name) || fileName.equalsIgnoreCase(name)) {
+                return doc;
+            }
+            if (firstDoc == null) {
+                firstDoc = doc;
+            }
+        }
+        return firstDoc;
+    }
+
+    @Nullable
+    private static KtFile ktFile(@NotNull ProjectViewNode<?> node, @NotNull Project project) {
+        Object value = node.getValue();
+        if (value instanceof KtFile) {
+            return (KtFile) value;
+        }
+        if (value instanceof PsiFile && !(value instanceof KtFile)) {
+            return null;
+        }
+        @Nullable VirtualFile virtualFile = node.getVirtualFile();
+        if (virtualFile == null || !virtualFile.isValid() || virtualFile.isDirectory()) {
+            return null;
+        }
+        @Nullable PsiFile psiFile = PsiManager.getInstance(project).findFile(virtualFile);
+        if (psiFile instanceof KtFile) {
+            return (KtFile) psiFile;
+        }
+        return null;
+    }
+
+    @NotNull
+    private static String fileNameWithoutExtension(@NotNull PsiFile psiFile) {
+        @NotNull String fileName = psiFile.getName();
+        int lastDot = fileName.lastIndexOf('.');
+        return lastDot > 0 ? fileName.substring(0, lastDot) : fileName;
     }
 
     @Override

--- a/src/main/java/io/github/linwancen/plugin/show/settings/AbstractSettingsState.java
+++ b/src/main/java/io/github/linwancen/plugin/show/settings/AbstractSettingsState.java
@@ -94,6 +94,7 @@ public abstract class AbstractSettingsState {
         put("asciidoc", new Pattern[]{Pattern.compile("(?m)^=++ (.*)")});
         put("bpmn", new Pattern[]{Pattern.compile("(?m)name=\"([^\"]*)")});
         put("dmn", new Pattern[]{Pattern.compile("(?m)name=\"([^\"]*)")});
+        put("kt", new Pattern[]{Pattern.compile("(?s)\\R\\s*/\\*\\*(.*?)\\*/\\s*(?:@[\\w.]+(?:\\([^)]*\\))?\\s*)*(?:public\\s+|private\\s+|internal\\s+|protected\\s+|actual\\s+|expect\\s+|inline\\s+|tailrec\\s+|operator\\s+|infix\\s+|suspend\\s+|data\\s+|sealed\\s+|enum\\s+|annotation\\s+|value\\s+|fun\\s+|class\\s+|interface\\s+|object\\s+|val\\s+|var\\s+)")});
         put("sh", new Pattern[]{Pattern.compile("(?m)^#++ *([^!].*)")});
     }};
 

--- a/src/main/java/io/github/linwancen/plugin/show/tree/FileDoc.java
+++ b/src/main/java/io/github/linwancen/plugin/show/tree/FileDoc.java
@@ -3,6 +3,7 @@ package io.github.linwancen.plugin.show.tree;
 import com.intellij.ide.projectView.impl.nodes.PsiFileNode;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import io.github.linwancen.plugin.show.bean.SettingsInfo;
 import io.github.linwancen.plugin.show.settings.AbstractSettingsState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -15,6 +16,12 @@ class FileDoc {
 
     @Nullable
     static String fileDoc(@NotNull PsiFileNode node, @NotNull AbstractSettingsState settings) {
+        return fileDoc(node, settings, null);
+    }
+
+    @Nullable
+    static String fileDoc(@NotNull PsiFileNode node, @NotNull AbstractSettingsState settings,
+                          @Nullable SettingsInfo info) {
         if (!settings.fileDocEffect) {
             return null;
         }
@@ -35,6 +42,6 @@ class FileDoc {
         if (patterns == null) {
             return null;
         }
-        return FilePatternsDoc.filePatternsDoc(psiFile, patterns);
+        return FilePatternsDoc.filePatternsDoc(info, psiFile, patterns);
     }
 }

--- a/src/main/java/io/github/linwancen/plugin/show/tree/FilePatternsDoc.java
+++ b/src/main/java/io/github/linwancen/plugin/show/tree/FilePatternsDoc.java
@@ -2,6 +2,8 @@ package io.github.linwancen.plugin.show.tree;
 
 import com.intellij.lang.FileASTNode;
 import com.intellij.psi.PsiFile;
+import io.github.linwancen.plugin.show.bean.SettingsInfo;
+import io.github.linwancen.plugin.show.lang.base.DocFilter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,6 +15,11 @@ class FilePatternsDoc {
 
     @Nullable
     static String filePatternsDoc(@NotNull PsiFile psiFile, @NotNull Pattern[] patterns) {
+        return filePatternsDoc(null, psiFile, patterns);
+    }
+
+    @Nullable
+    static String filePatternsDoc(@Nullable SettingsInfo info, @NotNull PsiFile psiFile, @NotNull Pattern[] patterns) {
         @Nullable FileASTNode fileNode = psiFile.getNode();
         if (fileNode == null) {
             return null;
@@ -23,6 +30,9 @@ class FilePatternsDoc {
             if (matcher.find()) {
                 String group = matcher.group(1);
                 if (group != null) {
+                    if (info != null) {
+                        group = DocFilter.cutDoc(group, info, true);
+                    }
                     group = group.trim();
                     if (!group.isEmpty()) {
                         return group;

--- a/src/main/java/io/github/linwancen/plugin/show/tree/RelFileDoc.java
+++ b/src/main/java/io/github/linwancen/plugin/show/tree/RelFileDoc.java
@@ -19,21 +19,27 @@ public class RelFileDoc {
         @NotNull ProjectSettingsState projectSettings = info.projectSettings;
         @NotNull GlobalSettingsState globalSettings = info.globalSettings;
         if (projectSettings.projectFilterEffective) {
-            @Nullable String doc = relDoc(node, projectSettings);
+            @Nullable String doc = relDoc(node, projectSettings, info);
             if (StringUtils.isNotBlank(doc)) {
                 return doc;
             }
         }
         if (projectSettings.globalFilterEffective) {
-            return relDoc(node, globalSettings);
+            return relDoc(node, globalSettings, info);
         }
         return null;
     }
 
     @Nullable
     private static String relDoc(ProjectViewNode<?> node, @NotNull AbstractSettingsState settings) {
+        return relDoc(node, settings, null);
+    }
+
+    @Nullable
+    private static String relDoc(ProjectViewNode<?> node, @NotNull AbstractSettingsState settings,
+                                 @Nullable SettingsInfo info) {
         if (node instanceof PsiFileNode) {
-            return FileDoc.fileDoc((PsiFileNode) node, settings);
+            return FileDoc.fileDoc((PsiFileNode) node, settings, info);
         } else if (node instanceof PsiDirectoryNode) {
             return DirDoc.dirDoc((PsiDirectoryNode) node, settings);
         }


### PR DESCRIPTION
## Summary
- add Kotlin PSI-based project tree documentation lookup
- add Kotlin file-pattern fallback for tree comments
- allow Gradle builds to opt into downloaded IntelliJ SDKs with `-PuseDownloadedIdea=true`

## Verification
- `GRADLE_USER_HOME=/tmp/show-comment-gradle-home JAVA_HOME=/Users/zjarlin/Library/Java/JavaVirtualMachines/corretto-17.0.12/Contents/Home /tmp/gradle-7.4/bin/gradle buildPlugin -PuseDownloadedIdea=true --no-configuration-cache -x buildSearchableOptions`